### PR TITLE
Use shelljs instead of fs.mkdirSync for recursive directory creation

### DIFF
--- a/Peepub.js
+++ b/Peepub.js
@@ -5,6 +5,7 @@ var _            = require('lodash');
 var handlebars   = require('handlebars');
 var cheerio      = require('cheerio');
 var Q            = require('q');
+var shell        = require('shelljs');
 var JSZip        = require('./src/libs/jszip.js');
 var archiver     = require('archiver');
 var utils        = require('./src/utils.js');
@@ -143,7 +144,7 @@ Peepub.prototype._epubPath = function(add){
   }
 
   if(!fs.existsSync(dir)){
-    fs.mkdirSync(dir);
+    shell.mkdir('-p', dir);
 
     // set up the whole structure
     if(!add){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1588 @@
+{
+  "name": "pe-epub",
+  "version": "0.3.8",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "Base64": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.1.4.tgz",
+      "integrity": "sha1-6fbGvvVn/WNepBYqsU3TKedKpt4=",
+      "dev": true
+    },
+    "CSSselect": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
+      "integrity": "sha1-5AVMZ7RnRl88lQDA2gqnh4xLq9I=",
+      "requires": {
+        "CSSwhat": "0.4.7",
+        "boolbase": "1.0.0",
+        "domutils": "1.4.3",
+        "nth-check": "1.0.1"
+      }
+    },
+    "CSSwhat": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+      "integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s="
+    },
+    "JSONStream": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
+      "integrity": "sha1-SyyAY/j1Enh7I3X37p22kgj6Lcs=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.2.7"
+      },
+      "dependencies": {
+        "through": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
+          "dev": true
+        }
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "archiver": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.9.1.tgz",
+      "integrity": "sha1-aayZZ7QpcYU0VYLapd7vv8tmQEY=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "file-utils": "0.1.5",
+        "lazystream": "0.1.0",
+        "lodash": "2.4.2",
+        "readable-stream": "1.0.34",
+        "tar-stream": "0.3.3",
+        "zip-stream": "0.3.7"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.7.0",
+        "underscore.string": "2.4.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "astw": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-0.0.0.tgz",
+      "integrity": "sha1-RJCGaj7xFqr5GtumPKfd9wttWb0=",
+      "dev": true,
+      "requires": {
+        "esprima": "1.0.2"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.2.tgz",
+          "integrity": "sha1-gDm/nOrE2dLBX2IyZPspK1UCzq8=",
+          "dev": true
+        }
+      }
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q=",
+      "dev": true
+    },
+    "bl": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.6.0.tgz",
+      "integrity": "sha1-MJECmZNylBM4RO40qkeaU0S0zSk=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "bops": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
+      "dev": true,
+      "requires": {
+        "base64-js": "0.0.2",
+        "to-utf8": "0.0.1"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-builtins": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/browser-builtins/-/browser-builtins-1.0.7.tgz",
+      "integrity": "sha1-xU3/T/D9espBH8a8LW4B9UR+Y9M=",
+      "dev": true,
+      "requires": {
+        "buffer-browserify": "0.1.0",
+        "console-browserify": "0.1.6",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "1.0.9",
+        "http-browserify": "0.1.14",
+        "punycode": "1.2.4",
+        "resolve": "0.3.1",
+        "vm-browserify": "0.0.4",
+        "zlib-browserify": "0.0.3"
+      }
+    },
+    "browser-pack": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-0.9.4.tgz",
+      "integrity": "sha1-yMycox894Gd/1UVJOvi97hS2Dxs=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "0.6.4",
+        "combine-source-map": "0.1.3",
+        "through": "2.3.8"
+      }
+    },
+    "browser-resolve": {
+      "version": "git://github.com/substack/node-browser-resolve.git#2bf4edad2205a05ebfe8fe1b836401120081ebc5",
+      "dev": true,
+      "requires": {
+        "resolve": "0.4.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.4.0.tgz",
+          "integrity": "sha1-Ux1XL6sFThLon9VFrWWy5JVVw0w=",
+          "dev": true
+        }
+      }
+    },
+    "browserify": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-2.18.1.tgz",
+      "integrity": "sha1-zznj0BXA+nneZ8tXLSH+I4vQ6sI=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "0.6.4",
+        "browser-builtins": "1.0.7",
+        "browser-pack": "0.9.4",
+        "browser-resolve": "git://github.com/substack/node-browser-resolve.git#2bf4edad2205a05ebfe8fe1b836401120081ebc5",
+        "concat-stream": "0.1.1",
+        "duplexer": "0.0.4",
+        "inherits": "1.0.2",
+        "insert-module-globals": "0.2.1",
+        "module-deps": "0.10.3",
+        "optimist": "0.5.2",
+        "shell-quote": "0.0.1",
+        "syntax-error": "0.0.1",
+        "through": "2.3.8",
+        "umd": "1.1.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.5.2.tgz",
+          "integrity": "sha1-hcjBRUszFeSniUfoV7HfAzRQv7w=",
+          "dev": true,
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
+        }
+      }
+    },
+    "browserify-shim": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-2.0.10.tgz",
+      "integrity": "sha1-dKDtW5t4SlooeQZROoltMfVKhLg=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "buffer-browserify": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-browserify/-/buffer-browserify-0.1.0.tgz",
+      "integrity": "sha1-rirwPfaIaV+ja+BfWSyBoGMpjd8=",
+      "dev": true,
+      "requires": {
+        "base64-js": "0.0.2"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
+    "bytes": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.1.0.tgz",
+      "integrity": "sha1-xXSBIigSbWNp0VdpJahXnbP45aI=",
+      "dev": true
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
+    "cheerio": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.10.8.tgz",
+      "integrity": "sha1-7OWtDIuqm5rchzlLvbHGi8RVK6A=",
+      "requires": {
+        "cheerio-select": "0.0.3",
+        "entities": "0.5.0",
+        "htmlparser2": "2.6.0",
+        "underscore": "1.4.4"
+      }
+    },
+    "cheerio-select": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
+      "integrity": "sha1-PyQgEU88ywsbB1wkXM+q5dYXo4g=",
+      "requires": {
+        "CSSselect": "0.7.0"
+      }
+    },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "combine-source-map": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.1.3.tgz",
+      "integrity": "sha1-3bdZOg8WcriCEnAiUBR7xOnqlc8=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "0.2.6",
+        "inline-source-map": "0.2.5",
+        "parse-base64vlq-mappings": "0.1.4"
+      }
+    },
+    "commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+      "dev": true
+    },
+    "commondir": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.2.tgz",
+      "integrity": "sha1-xJyIgMb+loRLs1Jd0ucxQFDDie4=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-0.1.1.tgz",
+      "integrity": "sha1-1/TieLkM/E8PPvd/5MA7QOs/eQA=",
+      "dev": true
+    },
+    "connect": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-2.7.2.tgz",
+      "integrity": "sha1-EXmUY72qr5nV+b7xM78kILJuJoA=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.1.1",
+        "bytes": "0.1.0",
+        "cookie": "0.0.5",
+        "cookie-signature": "0.0.1",
+        "debug": "1.0.5",
+        "formidable": "1.0.11",
+        "fresh": "0.1.0",
+        "pause": "0.0.1",
+        "qs": "0.5.1",
+        "send": "0.1.0"
+      },
+      "dependencies": {
+        "buffer-crc32": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.1.1.tgz",
+          "integrity": "sha1-fhENyZU5CKt8MqzccMn5RbHLxSY=",
+          "dev": true
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz",
+      "integrity": "sha1-0SijwLuINQ61YmxufHGm8P1ImDw=",
+      "dev": true
+    },
+    "constants-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.2.6.tgz",
+      "integrity": "sha1-rg7XNuimNEpYtQqJRyPeXIUd4tQ=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz",
+      "integrity": "sha1-+az521frdWjJ/MWWJWt7si4wfIE=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz",
+      "integrity": "sha1-E9NgO1z2O++/haiAHjeqkA20aYU=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc32-stream": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.2.0.tgz",
+      "integrity": "sha1-XIDUgMhoL5BLbxVTDbvguMBj274=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "readable-stream": "1.0.34"
+      }
+    },
+    "crypto-browserify": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "debug": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.5.tgz",
+      "integrity": "sha1-9yQSF0MPmd7EwrRz6rkiKOh0wqw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+      "integrity": "sha1-mWedO70EcVb81FDT0B7rkGhpHoM=",
+      "dev": true
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "deflate-crc32-stream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/deflate-crc32-stream/-/deflate-crc32-stream-0.1.2.tgz",
+      "integrity": "sha1-l16g5zA7ddhSMhmKt7QFwtR7qtU=",
+      "requires": {
+        "buffer-crc32": "0.2.13"
+      }
+    },
+    "detective": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-2.1.2.tgz",
+      "integrity": "sha1-0irZ8YyC77P1X+4uJEiD2mu7jjc=",
+      "dev": true,
+      "requires": {
+        "escodegen": "0.0.15",
+        "esprima": "1.0.2"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.2.tgz",
+          "integrity": "sha1-gDm/nOrE2dLBX2IyZPspK1UCzq8=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    },
+    "domhandler": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz",
+      "integrity": "sha1-iJ+N9iZAOvB4jinWbV1cb36/D9Y=",
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "duplexer": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
+      "integrity": "sha1-r8t/H4uNdPggcmFx1dZKyeSo/yA=",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+      "requires": {
+        "once": "1.3.3"
+      }
+    },
+    "entities": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
+      "integrity": "sha1-9hHLWuIhBQ4AEsZpeVA/164ZzEk="
+    },
+    "escodegen": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.15.tgz",
+      "integrity": "sha1-/9qcsmtws098wZ8diHVlOa+1Q70=",
+      "dev": true,
+      "requires": {
+        "esprima": "1.0.4",
+        "source-map": "0.1.43"
+      }
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "express": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/express/-/express-3.0.6.tgz",
+      "integrity": "sha1-0nT8uGi5V4i/SvYhaNddE/132LQ=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.1.1",
+        "commander": "0.6.1",
+        "connect": "2.7.2",
+        "cookie": "0.0.5",
+        "cookie-signature": "0.0.1",
+        "debug": "1.0.5",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "mkdirp": "0.3.3",
+        "range-parser": "0.0.4",
+        "send": "0.1.0"
+      },
+      "dependencies": {
+        "buffer-crc32": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.1.1.tgz",
+          "integrity": "sha1-fhENyZU5CKt8MqzccMn5RbHLxSY=",
+          "dev": true
+        }
+      }
+    },
+    "file-utils": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/file-utils/-/file-utils-0.1.5.tgz",
+      "integrity": "sha1-3IFTyFU4fLTaywoXJVMfpESmtIw=",
+      "requires": {
+        "findup-sync": "0.1.3",
+        "glob": "3.2.11",
+        "iconv-lite": "0.2.11",
+        "isbinaryfile": "0.1.9",
+        "lodash": "2.1.0",
+        "minimatch": "0.2.14",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.1.0.tgz",
+          "integrity": "sha1-Bjfqqjaooc/IZcOt+5Qhib+wmY0="
+        }
+      }
+    },
+    "fileset": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
+      "dev": true,
+      "requires": {
+        "glob": "3.2.11",
+        "minimatch": "0.2.14"
+      }
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "requires": {
+        "glob": "3.2.11",
+        "lodash": "2.4.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "follow-redirects": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
+      "integrity": "sha1-bOZ6JNsf4T8ibBFxpyp+8rF7j2U=",
+      "requires": {
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
+      }
+    },
+    "formidable": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.11.tgz",
+      "integrity": "sha1-aPYzJaA15kS297s9ESQ7l2HeGzA=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz",
+      "integrity": "sha1-A+SwF4Qk5MLV0ZpU2IFM3JeTSFA=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "gaze": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
+      "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
+      "dev": true,
+      "requires": {
+        "fileset": "0.1.8",
+        "minimatch": "0.2.14"
+      }
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.3.3",
+        "colors": "0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.1.3",
+        "getobject": "0.1.0",
+        "glob": "3.1.21",
+        "grunt-legacy-log": "0.1.3",
+        "grunt-legacy-util": "0.2.0",
+        "hooker": "0.2.3",
+        "iconv-lite": "0.2.11",
+        "js-yaml": "2.0.5",
+        "lodash": "0.9.2",
+        "minimatch": "0.2.14",
+        "nopt": "1.0.10",
+        "rimraf": "2.2.8",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          }
+        },
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-browserify": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-1.0.5.tgz",
+      "integrity": "sha1-V3UDnGzbjBfmNxFSv3+5zXpdU/g=",
+      "dev": true,
+      "requires": {
+        "browserify": "2.18.1",
+        "browserify-shim": "2.0.10"
+      }
+    },
+    "grunt-contrib-handlebars": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-handlebars/-/grunt-contrib-handlebars-0.5.12.tgz",
+      "integrity": "sha1-/a+Wm7yjLLIAg9WOqGAgn5KjWMc=",
+      "dev": true,
+      "requires": {
+        "grunt-lib-contrib": "0.5.3",
+        "handlebars": "1.0.12"
+      }
+    },
+    "grunt-jslint": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/grunt-jslint/-/grunt-jslint-0.2.6.tgz",
+      "integrity": "sha1-Ip+icd9dDU7aEd/6OPZ7X17QJ3c=",
+      "dev": true
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "grunt-legacy-log-utils": "0.1.1",
+        "hooker": "0.2.3",
+        "lodash": "2.4.2",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "lodash": "2.4.2",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "0.9.2",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-lib-contrib": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.5.3.tgz",
+      "integrity": "sha1-6D+e5cigZZLW6CWCHZEhB4IIEzg=",
+      "dev": true,
+      "requires": {
+        "zlib-browserify": "0.0.1"
+      },
+      "dependencies": {
+        "zlib-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz",
+          "integrity": "sha1-T6akXQDbwV8xikr6HZr8Aljhdsw=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-release": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/grunt-release/-/grunt-release-0.3.5.tgz",
+      "integrity": "sha1-XNK67RAHgKQhJgN5QJnN5aydX1o=",
+      "dev": true,
+      "requires": {
+        "semver": "1.1.4",
+        "shelljs": "0.1.4"
+      },
+      "dependencies": {
+        "shelljs": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz",
+          "integrity": "sha1-37vnjVbDwBaNL7eeEOzR28sH7A4=",
+          "dev": true
+        }
+      }
+    },
+    "handlebars": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
+      "integrity": "sha1-GMbTRAw16RsZs/9YK5FRq0mF1Pw=",
+      "requires": {
+        "optimist": "0.3.7",
+        "uglify-js": "2.3.6"
+      }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-2.6.0.tgz",
+      "integrity": "sha1-soVk6p0bpWoQSs5qew/dovMVg28=",
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.0.3",
+        "domutils": "1.0.1"
+      },
+      "dependencies": {
+        "domutils": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.0.1.tgz",
+          "integrity": "sha1-WLWNd0d0kRVWwWuLAtmcYJ2YeGk=",
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        }
+      }
+    },
+    "http-browserify": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-0.1.14.tgz",
+      "integrity": "sha1-nIs/lAAiBFR8fL5Saa/i6mL3HH8=",
+      "dev": true,
+      "requires": {
+        "Base64": "0.1.4",
+        "concat-stream": "1.0.1"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.0.1.tgz",
+          "integrity": "sha1-AYsYvBx9BzotyCqkhEI0GixN158=",
+          "dev": true,
+          "requires": {
+            "bops": "0.0.6"
+          }
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.3.3",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inline-source-map": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.2.5.tgz",
+      "integrity": "sha1-JC/2wYufsJNPep6DwUIZxhwTFnA=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.1.43"
+      }
+    },
+    "insert-module-globals": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-0.2.1.tgz",
+      "integrity": "sha1-/4QL+WBkAzx/rn4SKqJIIZA0gF4=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "0.4.4",
+        "commondir": "0.0.2",
+        "duplexer": "0.0.4",
+        "lexical-scope": "0.0.15",
+        "process": "0.5.2",
+        "through": "2.2.7"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.4.4.tgz",
+          "integrity": "sha1-zCzxGShsRb4VBCPLwSjUgOm1SuI=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "0.0.5"
+          }
+        },
+        "through": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
+          "dev": true
+        }
+      }
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isbinaryfile": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-0.1.9.tgz",
+      "integrity": "sha1-Fe7ONcSrcI2JJNqZ+4dPK1zAtsQ="
+    },
+    "jasmine-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine-node/-/jasmine-node-1.4.0.tgz",
+      "integrity": "sha1-SUlVna0vCukgdxGYGcdxzDH9bCY=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "1.3.3",
+        "gaze": "0.3.4",
+        "jasmine-reporters": "2.2.1",
+        "requirejs": "2.3.5",
+        "underscore": "1.4.4",
+        "walkdir": "0.0.12"
+      }
+    },
+    "jasmine-reporters": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.2.1.tgz",
+      "integrity": "sha1-3pqSATZ4RiaefKit/1tEIhZx/L0=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "xmldom": "0.1.27"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "0.1.16",
+        "esprima": "1.0.4"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonparse": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+      "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+      "dev": true
+    },
+    "lazystream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+      "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      }
+    },
+    "lexical-scope": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-0.0.15.tgz",
+      "integrity": "sha1-yllZl6rth7FVywQfSNwEOPSKBNw=",
+      "dev": true,
+      "requires": {
+        "astw": "0.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
+    "methods": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+      "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.6.tgz",
+      "integrity": "sha1-sfhsdowCX6h7SAdfFwnyiuryA2U=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
+      "integrity": "sha1-WV4lHBNww6aLqyE20ONIuBBa3xM=",
+      "dev": true
+    },
+    "module-deps": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-0.10.3.tgz",
+      "integrity": "sha1-jWj0E/6lu3aH+vFkhNS5HDpHOlo=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "0.6.4",
+        "browser-resolve": "git://github.com/substack/node-browser-resolve.git#2bf4edad2205a05ebfe8fe1b836401120081ebc5",
+        "concat-stream": "1.0.1",
+        "detective": "2.1.2",
+        "resolve": "0.4.3",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.0.1.tgz",
+          "integrity": "sha1-AYsYvBx9BzotyCqkhEI0GixN158=",
+          "dev": true,
+          "requires": {
+            "bops": "0.0.6"
+          }
+        },
+        "resolve": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.4.3.tgz",
+          "integrity": "sha1-3K2tIC58rMJGfjo4gAIR9C+cE98=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
+    "once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
+    "parse-base64vlq-mappings": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/parse-base64vlq-mappings/-/parse-base64vlq-mappings-0.1.4.tgz",
+      "integrity": "sha1-/PXd3tOaAQ3449xgnIbtAQF9+pg=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
+      "dev": true
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+      "integrity": "sha1-VACKyXKux0F13vnLpt9/qdORh0A=",
+      "dev": true
+    },
+    "q": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+      "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
+    },
+    "qs": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.1.tgz",
+      "integrity": "sha1-n2v12axsdjhOldNtFbSJgOXkrdA=",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+      "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        }
+      }
+    },
+    "requirejs": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.5.tgz",
+      "integrity": "sha512-svnO+aNcR/an9Dpi44C7KSAy5fFGLtmPbaaCeQaklUz8BQhS64tWWIIlvEA5jrWICzlO/X9KSzSeXFnZdBu8nw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+      "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
+      "dev": true
+    },
+    "rfile": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+      "integrity": "sha1-WXCM+Qyh50xUw8/Fw2/bmBBDUmE=",
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0",
+        "resolve": "0.3.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+    },
+    "ruglify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+      "integrity": "sha1-3Ikw4qlUSidDAcyZcldMDQmGtnU=",
+      "dev": true,
+      "requires": {
+        "rfile": "1.0.0",
+        "uglify-js": "2.2.5"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+          "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
+          "dev": true,
+          "requires": {
+            "optimist": "0.3.7",
+            "source-map": "0.1.43"
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz",
+      "integrity": "sha1-LlpOcrqwNHLMl/cnU7RQiRLvVUA=",
+      "dev": true
+    },
+    "send": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.1.0.tgz",
+      "integrity": "sha1-z7COvTzsm3/Bo32f+eh1qXHPRkA=",
+      "dev": true,
+      "requires": {
+        "debug": "1.0.5",
+        "fresh": "0.1.0",
+        "mime": "1.2.6",
+        "range-parser": "0.0.4"
+      }
+    },
+    "shell-quote": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+      "integrity": "sha1-GkEZbzwDM8SCMjWT1ohuzxU92YY=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "syntax-error": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-0.0.1.tgz",
+      "integrity": "sha1-AZ0HU0jNjFt58GA8c+U4kafFI10=",
+      "dev": true,
+      "requires": {
+        "esprima": "0.9.9"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "0.9.9",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-0.9.9.tgz",
+          "integrity": "sha1-G5CSXJddYy1ygpOcO7nDpCPDBJA=",
+          "dev": true
+        }
+      }
+    },
+    "tape": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-0.2.2.tgz",
+      "integrity": "sha1-ZMz6S37PSgBgAH5hcW1CR4FnFjc=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "0.0.0",
+        "defined": "0.0.0",
+        "jsonify": "0.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.3.3.tgz",
+      "integrity": "sha1-I8pTvXOLhwInKoDibMk4vEuEuHs=",
+      "requires": {
+        "bl": "0.6.0",
+        "end-of-stream": "0.1.5",
+        "readable-stream": "1.0.34"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+      "requires": {
+        "async": "0.2.10",
+        "optimist": "0.3.7",
+        "source-map": "0.1.43"
+      }
+    },
+    "umd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-1.1.1.tgz",
+      "integrity": "sha1-SBtkZVsbPbDB85ECJcOAT8bX7Fg=",
+      "dev": true,
+      "requires": {
+        "rfile": "1.0.0",
+        "ruglify": "1.0.0",
+        "through": "2.3.8",
+        "uglify-js": "2.2.5"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+          "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
+          "dev": true,
+          "requires": {
+            "optimist": "0.3.7",
+            "source-map": "0.1.43"
+          }
+        }
+      }
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "walkdir": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.12.tgz",
+      "integrity": "sha512-HFhaD4mMWPzFSqhpyDG48KDdrjfn409YQuVW7ckZYhW4sE87mYtWifdB/+73RA7+p4s4K18n5Jfx1kHthE1gBw==",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    },
+    "zip-stream": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.3.7.tgz",
+      "integrity": "sha1-yE0FfrC8wBOXR708bJcoC89fK7I=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "0.2.0",
+        "debug": "1.0.5",
+        "deflate-crc32-stream": "0.1.2",
+        "lodash": "2.4.2",
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "zlib-browserify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.3.tgz",
+      "integrity": "sha1-JAzNv9AgP6hCsTDe77FBQSLIzFA=",
+      "dev": true,
+      "requires": {
+        "tape": "0.2.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "follow-redirects": "0.0.3",
     "handlebars": "~1.0.11",
     "lodash": "*",
-    "q": "~0.9.7"
+    "q": "~0.9.7",
+    "shelljs": "^0.7.8"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Hi @owise1! I work with Greg Albers at the Getty. We are trying to use Peoples-Epub as a piece in a larger tool we are building and I think I found a bug when this project runs on more modern versions of Node. After this fix I can successfully build a basic Epub from your example JSON, whereas before I could not. Happy to discuss further here or answer any questions.

## Problem:

In Node v8.9.0 (current LTS release), Pe-Epub would fail to build an epub properly due to an inability to create recursive sub-directories in the course of tasks like building an OPF file.

For example, the following error is thrown when running most of the tests:

```
Error: ENOENT: no such file or directory, mkdir '/Users/eric/dev/pe-epub/epubs/22ba6566-84a9-87ed-3039-59e6c9835cae/
```

Pe-Epub is attempting to create an `epubs` directory with a subdirectory of the randomly-generated book ID, but (at least in Node v8) fs.mkdir can't handle creation of multiple nested directories at once.

## Proposed solution:

This commit fixes this error by modifying the `Peepub._epubPath()` method to use `shell.mkdir()` with the `-p` flag to support recursive directory creation. Shelljs works on Unix platforms as well as Windows.

After this change, all tests pass locally except one of the TOC specs ("TOC functionality will create a toc link to the first page if you haven't put any pages in the TOC"). I believe this is a separate issue
which can be addressed in a later commit.

Tests have been run on a Macbook Pro running Sierra, using NodeJS v8.9.0.